### PR TITLE
Fix bad file path in header

### DIFF
--- a/externals/essentials/source/essentials/include/essentials/non_copyable.hpp
+++ b/externals/essentials/source/essentials/include/essentials/non_copyable.hpp
@@ -12,7 +12,7 @@
 #define NON_COPYABLE_D2C5BF6C_4B43_42AF_9E42_1AAE2B5C49C8
 
 
-#include "essentials/compatibility/compatibility.hpp"
+#include "compatibility/compatibility.hpp"
 
 
 namespace sxe


### PR DESCRIPTION
The current file path is neither relative nor absolute and causes build failures.